### PR TITLE
Fix activeVoices erase

### DIFF
--- a/Microtone/src/synthesizer/synthesizer.cpp
+++ b/Microtone/src/synthesizer/synthesizer.cpp
@@ -205,7 +205,8 @@ public:
             }
         }
 
-        for (const auto& id : _activeVoices) {
+        const auto activeVoices = _activeVoices;
+        for (const auto& id : activeVoices) {
             if (!_voices[id].isActive()) {
                 _activeVoices.erase(id);
             }


### PR DESCRIPTION
Trivial PR to fix a Segfault when an active voice must be erased while iterating it for ids
(Seen on Linux using GCC)

The fix is to simply copy the activeVoices container, iterating on the copy, then erasing the main container